### PR TITLE
Set default editor to notepad

### DIFF
--- a/ansible_vault/vault.py
+++ b/ansible_vault/vault.py
@@ -1,6 +1,7 @@
 import logging
 import os
 import os.path
+import platform
 import shlex
 import shutil
 import subprocess
@@ -550,7 +551,11 @@ class VaultEditor:
     shutil.move(src, dest)
 
   def _editor_shell_command(self, filename):
-    env_editor = os.environ.get('EDITOR', 'nano')
+    if platform.system() == 'Windows':
+      env_editor = os.environ.get('EDITOR', 'notepad')
+    else:
+      env_editor = os.environ.get('EDITOR', 'nano')
+
     editor = shlex.split(env_editor)
     editor.append(filename)
 


### PR DESCRIPTION
Hi Ben, this is great.

I updated the default editor used for Windows. Just if anyone to come across this.

The editor could also be set by running
`$Env:EDITOR = "notepad.exe"`
in PowerShell.

I also had an error installing the package. It complained that Rust is required. Update pip to overcome this issue.

Kr